### PR TITLE
feat: persist predictions with Firebase auth

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -251,6 +251,7 @@
   <!-- Firebase -->
   <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-auth-compat.js"></script>
   <!-- Your app JS (defer so DOM exists) -->
   <script src="app.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary
- add Firebase Auth to web app
- save predictions per user with Firestore
- prepare helper to submit actual results later

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1dfc026708322a27ac1f0ac22bd8f