### PR TITLE
Auto-detect maths bonus and add info pages

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>About - Points Probability Calculator</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+</head>
+<body class="bg-light">
+  <div class="container py-4">
+    <h1>About</h1>
+    <p>Points Probability Calculator helps students estimate the likelihood of achieving their Leaving Cert target points by modelling grade probabilities for each subject.</p>
+    <p>For questions or feedback, contact <a href="mailto:iamharryashton@gmail.com">iamharryashton@gmail.com</a>.</p>
+    <p><a href="index.html">Back to calculator</a></p>
+  </div>
+</body>
+</html>

--- a/public/app.js
+++ b/public/app.js
@@ -24,8 +24,6 @@
         const stepTotal = Q('stepTotal');
         const subName = Q('subName');
         const subLevel = Q('subLevel');
-        const subMaths = Q('subMaths');
-        const mathsLockHint = Q('mathsLockHint');
         const gradePills = Q('gradePills');
         const remainingLabel = Q('remainingLabel');
         const remainingBar = Q('remainingBar');
@@ -125,22 +123,25 @@
         const pointsOrdinary = [56,46,37,28,20,12,0,0];
         const H_LABELS = ["H1","H2","H3","H4","H5","H6","H7","H8"];
         const O_LABELS = ["O1","O2","O3","O4","O5","O6","O7","O8"];
-  
-        const getPoints = (g, isMaths, level) =>
-          level === 'Ordinary' ? pointsOrdinary[g] : (isMaths ? pointsMathsHigher[g] : pointsHigher[g]);
-  
+
+        const getPoints = (g, name, level) => {
+          if (level === 'Ordinary') return pointsOrdinary[g];
+          const lower = name.trim().toLowerCase();
+          const isMaths = lower === 'mathematics' || lower === 'maths';
+          return isMaths ? pointsMathsHigher[g] : pointsHigher[g];
+        };
+
         // Model
-        let subjects = Array.from({length:6}, ()=>({name:"", level:"Higher", isMaths:false, probs:Array(8).fill(0)}));
+        let subjects = Array.from({length:6}, ()=>({name:"", level:"Higher", probs:Array(8).fill(0)}));
         let current = 0;
         let activeGrade = 0;
-        let mathsIndex = null;
         let targetDebounce = null;
         let histChart = null;
   
         /* ====== UI Wiring ====== */
         prevBtn.onclick = ()=> { if (current>0){ saveFromUI(); current--; renderWizard(); } };
         nextBtn.onclick = ()=> { if (current<subjects.length-1){ saveFromUI(); current++; renderWizard(); } };
-        addBtn .onclick = ()=> { saveFromUI(); subjects.push({name:"", level:"Higher", isMaths:false, probs:Array(8).fill(0)}); stepTotal.textContent=subjects.length; current=subjects.length-1; renderWizard(); };
+        addBtn .onclick = ()=> { saveFromUI(); subjects.push({name:"", level:"Higher", probs:Array(8).fill(0)}); stepTotal.textContent=subjects.length; current=subjects.length-1; renderWizard(); };
         finishBtn.onclick = ()=> {
           saveFromUI();
           if (!targetInput.value.trim()) {
@@ -148,15 +149,16 @@
             targetInput.focus();
             return;
           }
-          calculateAndRender();
+          const result = calculateAndRender();
+          const desiredMarks = Number(targetInput.value);
           const school = schoolInput.value.trim();
           const payload = {
             school,
-            target: Number(targetInput.value),
+            desiredMarks,
+            meanMarks: result ? result.mean : null,
             subjects: subjects.map(s => ({
               name: s.name,
               level: s.level,
-              isMaths: s.isMaths,
               probs: s.probs
             }))
           };
@@ -208,26 +210,6 @@
           subName.value = s.name;
           subName.placeholder = `Enter subject ${current+1}`;
           subLevel.value = s.level;
-  
-          // Maths single-select
-          const idx = subjects.findIndex(x => x.isMaths);
-          mathsIndex = (idx >= 0) ? idx : null;
-  
-          subMaths.checked = !!s.isMaths;
-          const locked = mathsIndex !== null && mathsIndex !== current;
-          subMaths.disabled = locked;
-          mathsLockHint.classList.toggle('d-none', !locked);
-  
-          subMaths.onchange = ()=>{
-            if (subMaths.checked){
-              if (mathsIndex !== null && mathsIndex !== current) subjects[mathsIndex].isMaths = false;
-              subjects[current].isMaths = true; mathsIndex = current;
-            } else {
-              if (mathsIndex === current) mathsIndex = null;
-              subjects[current].isMaths = false;
-            }
-            renderWizard();
-          };
   
           // name/level
           subName.oninput = ()=> {
@@ -295,8 +277,8 @@
             const rawSum = s.probs.reduce((a,b)=>a+b,0);
             const probs = rawSum>0 ? s.probs.map(p=>p/rawSum) : Array(8).fill(0); // skip empty later
             let expected=0;
-            for (let g=0; g<8; g++) expected += probs[g]*getPoints(g, s.isMaths, s.level);
-            return { name: s.name || `Subject ${idx+1}`, level: s.level, isMaths: s.isMaths, probs, expected, rawSum };
+            for (let g=0; g<8; g++) expected += probs[g]*getPoints(g, s.name, s.level);
+            return { name: s.name || `Subject ${idx+1}`, level: s.level, probs, expected, rawSum };
           });
         }
         function bestSix(list){
@@ -318,7 +300,7 @@
             const pts = [];
             for (let g=0; g<8; g++){
               const p = subj.probs[g];
-              if (p > 0) pts.push([ getPoints(g, subj.isMaths, subj.level), p ]);
+              if (p > 0) pts.push([ getPoints(g, subj.name, subj.level), p ]);
             }
             if (pts.length === 0) continue;
   
@@ -398,7 +380,7 @@
             selectionNote.textContent = 'No subjects yet — add at least one.';
             resultsEl.textContent = 'Awaiting input…';
             if (histChart) histChart.destroy();
-            return;
+            return null;
           }
   
           const {selected, dropped} = bestSix(prepared);
@@ -421,6 +403,7 @@
             </div>
           `;
           drawHistogram(dist, mean, stdDev);
+          return {mean, stdDev};
         }
   
         // expose for debug if you like
@@ -428,6 +411,11 @@
   
         // Initial render
         renderWizard();
+        const tutEl = document.getElementById('tutorialModal');
+        if (tutEl && typeof bootstrap !== 'undefined'){
+          const tut = new bootstrap.Modal(tutEl);
+          tut.show();
+        }
         // Don’t auto-calc on load; user hits Finish
         // calculateAndRender();
   

--- a/public/index.html
+++ b/public/index.html
@@ -45,6 +45,10 @@
       color:#6c757d; font-weight:600;
     }
     .ad-box .ad-inner{width:100%; height:100%; display:flex; align-items:center; justify-content:center; padding:8px;}
+    .nav-actions .btn-lg{font-weight:600;}
+    @media (max-width: 576px){
+      .nav-actions .btn-lg{width:100%;}
+    }
     @media (max-width: 991.98px){
       .ad-box{position:relative; top:auto; min-height:120px; margin-bottom:1rem;}
     }
@@ -56,6 +60,24 @@
 <body>
 
   <div id="errOverlay"><strong>Script error:</strong> <pre id="errText"></pre></div>
+
+  <!-- Tutorial Modal -->
+  <div class="modal fade" id="tutorialModal" tabindex="-1" aria-labelledby="tutorialLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="tutorialLabel">Welcome</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <p>Enter each subject one at a time, pick probabilities for each grade in the subject, go through each subject and then find out the likelihood of your expected points.</p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-main" data-bs-dismiss="modal">Got it</button>
+        </div>
+      </div>
+    </div>
+  </div>
 
   <!-- NAVBAR -->
   <nav class="navbar navbar-light sticky-top">
@@ -91,7 +113,7 @@
                 <input id="school" class="form-control mx-auto" style="max-width:300px" placeholder="Type your school">
               </div>
             </div>
-            <p class="text-muted mt-2 mb-0">Tap a grade (H1–H8 or O1–O8), then set its probability with the % grid or enter it manually below. The bar fills to 100%. Maths bonus applies only for <b>Higher</b>, and only one subject can be Maths.</p>
+            <p class="text-muted mt-2 mb-0">Tap a grade (H1–H8 or O1–O8), then set its probability with the % grid or enter it manually below. The bar fills to 100%. Bonus points are applied automatically for Higher level Mathematics.</p>
           </header>
 
           <!-- Wizard Card -->
@@ -109,25 +131,18 @@
                 <div class="col-12">
                   <div id="subjectCard" class="p-3 rounded" style="background:#fff; border:1px solid var(--border);">
                     <div class="row g-3">
-                      <div class="col-12 col-md-7">
+                      <div class="col-12 col-md-8">
                         <label class="form-label">Subject Name</label>
                         <input id="subName" class="form-control" list="subjectList" placeholder="">
                         <datalist id="subjectList"></datalist>
                         <div id="subjectLetters" class="letter-filter"></div>
                       </div>
-                      <div class="col-6 col-md-3">
+                      <div class="col-12 col-md-4">
                         <label class="form-label">Level</label>
                         <select id="subLevel" class="form-select">
                           <option value="Higher" selected>Higher</option>
                           <option value="Ordinary">Ordinary</option>
                         </select>
-                      </div>
-                      <div class="col-6 col-md-2 d-flex align-items-end">
-                        <div class="form-check">
-                          <input id="subMaths" type="checkbox" class="form-check-input">
-                          <label for="subMaths" class="form-check-label">Maths?</label>
-                          <div id="mathsLockHint" class="form-text d-none">Maths already set for another subject.</div>
-                        </div>
                       </div>
 
                       <!-- Grade pills -->
@@ -161,6 +176,14 @@
                 <div class="col-12">
                   <label class="form-label">Set probability for the selected grade</label>
 
+                  <div class="mb-3">
+                    <label for="probInput" class="form-label">Manual Probability</label>
+                    <div class="input-group">
+                      <input id="probInput" class="form-control" placeholder="e.g. 70 or 0.7">
+                      <button id="kpSet" class="btn btn-main" type="button">Set Value for Selected Grade</button>
+                    </div>
+                  </div>
+
                   <!-- Percent grid -->
                   <div class="mb-3">
                     <div class="d-grid gap-2" style="grid-template-columns: repeat(3, 1fr); display:grid;">
@@ -177,29 +200,21 @@
                       <button class="btn btn-outline-secondary pct" data-p="10">10%</button>
                     </div>
                   </div>
-
-                  <div class="mb-3">
-                    <label for="probInput" class="form-label">Manual Probability</label>
-                    <div class="input-group">
-                      <input id="probInput" class="form-control" placeholder="e.g. 70 or 0.7">
-                      <button id="kpSet" class="btn btn-main" type="button">Set Value for Selected Grade</button>
-                    </div>
-                  </div>
                 </div>
               </div>
 
               <hr class="my-4"/>
 
-              <div class="d-flex flex-wrap gap-2 justify-content-between">
-                <div>
-                  <button id="prevBtn" class="btn btn-outline-secondary">&larr; Previous</button>
-                  <button id="nextBtn" class="btn btn-outline-secondary">Next &rarr;</button>
-                  <button id="addBtn" class="btn btn-outline-secondary">+ Add Subject</button>
-                  <span class="ms-2 text-muted small">We’ll use your best 6 subjects when calculating.</span>
+              <div class="nav-actions d-flex flex-wrap gap-2 justify-content-between">
+                <div class="d-flex flex-wrap gap-2 flex-grow-1">
+                  <button id="prevBtn" class="btn btn-outline-secondary btn-lg flex-fill">&larr; Previous</button>
+                  <button id="nextBtn" class="btn btn-outline-secondary btn-lg flex-fill">Next &rarr;</button>
+                  <button id="addBtn" class="btn btn-outline-secondary btn-lg flex-fill">+ Add Subject</button>
                 </div>
-                <div>
-                  <button id="finishBtn" class="btn btn-main">Finish & Calculate</button>
+                <div class="flex-grow-1 flex-md-grow-0">
+                  <button id="finishBtn" class="btn btn-main btn-lg w-100">Finish & Calculate</button>
                 </div>
+                <span class="w-100 text-muted small">We’ll use your best 6 subjects when calculating.</span>
               </div>
             </div>
           </div>
@@ -243,6 +258,10 @@
       </aside>
     </div>
   </div>
+
+  <footer class="text-center my-4">
+    <a href="about.html">About</a> · <a href="privacy.html">Privacy</a>
+  </footer>
 
   <!-- Bootstrap JS -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Privacy Policy - Points Probability Calculator</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+</head>
+<body class="bg-light">
+  <div class="container py-4">
+    <h1>Privacy Policy</h1>
+    <p>This tool stores your subject selections and probability inputs to compute results. We record desired points and mean marks anonymously to improve the service.</p>
+    <p>No personal identifiers are collected. For privacy questions contact <a href="mailto:iamharryashton@gmail.com">iamharryashton@gmail.com</a>.</p>
+    <p><a href="index.html">Back to calculator</a></p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Remove manual maths checkbox and apply Higher Maths bonus automatically
- Update subject setup layout and footer links
- Add About and Privacy pages with contact email

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a31b2df18883228c9627a5ca1cca62