### PR TITLE
lastworkiign

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -42,8 +42,6 @@
         const histCanvas = Q('histogram');
         const subjectListEl = Q('subjectList');
         const subjectLetters = Q('subjectLetters');
-        // legacy element removed from markup; tolerate its absence
-        Q('subMaths', false);
 
         // Firebase setup
         const firebaseConfig = {
@@ -109,6 +107,11 @@
         };
 
         let subjectOptions = [];
+        subName.addEventListener('input', () => {
+          const q = subName.value.trim().toLowerCase();
+          const filtered = subjectOptions.filter(n => n.toLowerCase().includes(q));
+          renderOptions(subjectListEl, filtered);
+        });
         fetch('./subjects.json').then(r=>r.json()).then(list=>{
           subjectOptions = list;
           renderOptions(subjectListEl, list);

--- a/public/index.html
+++ b/public/index.html
@@ -75,7 +75,7 @@
     </div>
   </nav>
 
-  <div class="container-fluid">
+  <div class="container" style="max-width: 900px;">
     <div class="row g-3">
       <main class="col-12">
         <div class="py-3">


### PR DESCRIPTION
## Summary
- remove stale `subMaths` query that triggered a script error
- constrain desktop layout with a centered container
- add live filtering for subject list as user types

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a324b9e1f88322beb03b2fb751031c