### PR TITLE
Add signup prompt and results history page

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -7,7 +7,11 @@
       console.error(msg);
     };
   
-    window.addEventListener('error', (e)=> showErr(e.message || e.error));
+    window.addEventListener('error', (e)=> {
+      // Ignore generic cross-origin errors from third-party scripts
+      if (e.message === 'Script error.' && !e.filename) return;
+      showErr(e.message || e.error);
+    });
     window.addEventListener('unhandledrejection', (e)=> showErr(e.reason || 'Unhandled promise rejection'));
   
     window.addEventListener('DOMContentLoaded', () => {
@@ -73,6 +77,16 @@
             actualResults,
             updatedAt: firebase.firestore.FieldValue.serverTimestamp()
           });
+        }
+
+        function promptSignup(){
+          const user = auth.currentUser;
+          if (user && user.isAnonymous){
+            const go = confirm('Save this prediction and add your real results on 22/8? Sign up now!');
+            if (go){
+              window.location.href = 'results.html';
+            }
+          }
         }
 
         // Datalist helpers
@@ -169,6 +183,7 @@
           };
           submitPrediction(payload).then(id => {
             console.log('Saved submission', id);
+            promptSignup();
           }).catch(err => showErr(err.message || err));
         };
   

--- a/public/index.html
+++ b/public/index.html
@@ -71,6 +71,7 @@
       <div class="d-flex align-items-center gap-3">
         <a class="text-muted text-decoration-none" href="about.html">About</a>
         <a class="text-muted text-decoration-none" href="privacy.html">Privacy</a>
+        <a class="text-muted text-decoration-none" href="results.html">Results</a>
       </div>
     </div>
   </nav>
@@ -228,7 +229,7 @@
   </div>
 
   <footer class="text-center my-4">
-    <a href="about.html">About</a> · <a href="privacy.html">Privacy</a>
+    <a href="about.html">About</a> · <a href="privacy.html">Privacy</a> · <a href="results.html">Results</a>
   </footer>
 
   <!-- Bootstrap JS -->

--- a/public/results.html
+++ b/public/results.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Results - Points Probability Calculator</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous"/>
+</head>
+<body class="bg-light">
+
+  <!-- NAVBAR -->
+  <nav class="navbar navbar-light sticky-top">
+    <div class="container-fluid">
+      <a class="navbar-brand fw-semibold" href="index.html" style="color:#333;">LC Points</a>
+      <div class="d-flex align-items-center gap-3">
+        <a class="text-muted text-decoration-none" href="about.html">About</a>
+        <a class="text-muted text-decoration-none" href="privacy.html">Privacy</a>
+        <a class="text-muted text-decoration-none" href="results.html">Results</a>
+      </div>
+    </div>
+  </nav>
+
+  <div class="container py-4" style="max-width:800px;">
+    <div id="authSection" class="mb-4">
+      <h2 class="h5">Sign up or log in</h2>
+      <div class="row g-3">
+        <div class="col-md-6">
+          <h3 class="h6">Sign Up</h3>
+          <input id="signupEmail" class="form-control mb-2" type="email" placeholder="Email">
+          <input id="signupPassword" class="form-control mb-2" type="password" placeholder="Password">
+          <button id="signupBtn" class="btn btn-secondary">Sign Up</button>
+        </div>
+        <div class="col-md-6">
+          <h3 class="h6">Log In</h3>
+          <input id="loginEmail" class="form-control mb-2" type="email" placeholder="Email">
+          <input id="loginPassword" class="form-control mb-2" type="password" placeholder="Password">
+          <button id="loginBtn" class="btn btn-outline-secondary">Log In</button>
+        </div>
+      </div>
+    </div>
+
+    <div id="resultsSection" style="display:none;">
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2 class="h5 mb-0">Your Predictions</h2>
+        <button id="logoutBtn" class="btn btn-sm btn-outline-secondary">Log Out</button>
+      </div>
+      <ul id="predictionsList" class="list-group"></ul>
+    </div>
+  </div>
+
+  <footer class="text-center my-4">
+    <a href="about.html">About</a> · <a href="privacy.html">Privacy</a> · <a href="results.html">Results</a>
+  </footer>
+
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-auth-compat.js"></script>
+  <script src="results.js" defer></script>
+</body>
+</html>

--- a/public/results.js
+++ b/public/results.js
@@ -1,0 +1,88 @@
+(function(){
+  const firebaseConfig = {
+    apiKey: "AIzaSyAS5PvPMYQjCQz88drt1VG6B5Y2v3PpjZM",
+    authDomain: "lcpredic.firebaseapp.com",
+    projectId: "lcpredic"
+  };
+  firebase.initializeApp(firebaseConfig);
+  const db = firebase.firestore();
+  const auth = firebase.auth();
+
+  const authSection = document.getElementById('authSection');
+  const resultsSection = document.getElementById('resultsSection');
+  const predictionsList = document.getElementById('predictionsList');
+
+  function showAuth(){
+    authSection.style.display = 'block';
+    resultsSection.style.display = 'none';
+  }
+  function showResults(){
+    authSection.style.display = 'none';
+    resultsSection.style.display = 'block';
+    loadPredictions();
+  }
+
+  function loadPredictions(){
+    const uid = auth.currentUser.uid;
+    const ref = db.collection('users').doc(uid).collection('predictions').orderBy('createdAt','desc');
+    ref.get().then(snapshot => {
+      predictionsList.innerHTML = '';
+      snapshot.forEach(doc => {
+        const data = doc.data();
+        const li = document.createElement('li');
+        li.className = 'list-group-item';
+        const date = data.createdAt && data.createdAt.toDate ? data.createdAt.toDate().toLocaleDateString() : 'unknown';
+        const actual = data.actualResults ? data.actualResults : '<em>not added</em>';
+        li.innerHTML = `<div><strong>${data.desiredMarks ?? ''}</strong> points (mean ${data.meanMarks ?? ''}) - <small>${date}</small></div>` +
+                       `<div>Actual: ${actual} <button class="btn btn-sm btn-outline-primary ms-2 add-actual" data-id="${doc.id}">Add Actual</button></div>`;
+        predictionsList.appendChild(li);
+      });
+      predictionsList.querySelectorAll('.add-actual').forEach(btn => {
+        btn.addEventListener('click', () => {
+          const id = btn.getAttribute('data-id');
+          const val = prompt('Enter your actual results');
+          if (val){
+            const uid = auth.currentUser.uid;
+            db.collection('users').doc(uid).collection('predictions').doc(id).update({
+              actualResults: val,
+              updatedAt: firebase.firestore.FieldValue.serverTimestamp()
+            }).then(loadPredictions);
+          }
+        });
+      });
+    });
+  }
+
+  auth.onAuthStateChanged(user => {
+    if (user && !user.isAnonymous){
+      showResults();
+    } else {
+      showAuth();
+      if (!user){
+        auth.signInAnonymously().catch(err => alert(err.message));
+      }
+    }
+  });
+
+  document.getElementById('signupBtn').onclick = () => {
+    const email = document.getElementById('signupEmail').value;
+    const pass = document.getElementById('signupPassword').value;
+    const cred = firebase.auth.EmailAuthProvider.credential(email, pass);
+    const user = auth.currentUser;
+    if (user && user.isAnonymous){
+      user.linkWithCredential(cred).catch(err => alert(err.message));
+    } else {
+      auth.createUserWithEmailAndPassword(email, pass).catch(err => alert(err.message));
+    }
+  };
+
+  document.getElementById('loginBtn').onclick = () => {
+    const email = document.getElementById('loginEmail').value;
+    const pass = document.getElementById('loginPassword').value;
+    auth.signInWithEmailAndPassword(email, pass).catch(err => alert(err.message));
+  };
+
+  document.getElementById('logoutBtn').onclick = () => {
+    auth.signOut();
+  };
+})();


### PR DESCRIPTION
## Summary
- Prompt anonymous users to sign up after submitting a prediction
- Add navigation link to new results page
- Provide results page to sign up/login, review predictions, and record actual results
- Ignore generic cross-origin script errors that were showing a misleading error banner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a328200aa88322a78022f4fb3ff1eb