### PR TITLE
Fix caching and add mock results input

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="Cache-Control" content="no-store" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Points Probability Calculator — Wizard</title>
 
@@ -239,7 +240,7 @@
   <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-auth-compat.js"></script>
   <!-- Your app JS (defer so DOM exists) -->
-  <script src="app.js" defer></script>
+  <script src="app.js?v=1" defer></script>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7429797559685152"
      crossorigin="anonymous"></script>
 </body>

--- a/public/results.html
+++ b/public/results.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="Cache-Control" content="no-store" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Results - Points Probability Calculator</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous"/>
@@ -55,6 +56,6 @@
   <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-auth-compat.js"></script>
-  <script src="results.js" defer></script>
+  <script src="results.js?v=1" defer></script>
 </body>
 </html>

--- a/public/results.js
+++ b/public/results.js
@@ -32,22 +32,22 @@
         const li = document.createElement('li');
         li.className = 'list-group-item';
         const date = data.createdAt && data.createdAt.toDate ? data.createdAt.toDate().toLocaleDateString() : 'unknown';
-        const actual = data.actualResults ? data.actualResults : '<em>not added</em>';
+        const actualVal = data.actualResults ? data.actualResults : '';
         li.innerHTML = `<div><strong>${data.desiredMarks ?? ''}</strong> points (mean ${data.meanMarks ?? ''}) - <small>${date}</small></div>` +
-                       `<div>Actual: ${actual} <button class="btn btn-sm btn-outline-primary ms-2 add-actual" data-id="${doc.id}">Add Actual</button></div>`;
+                       `<div class="mt-2 d-flex align-items-center gap-2"><input type="text" class="form-control form-control-sm actual-input" placeholder="Enter mock results" value="${actualVal}"><button class="btn btn-sm btn-outline-primary save-actual" data-id="${doc.id}">Save</button></div>`;
         predictionsList.appendChild(li);
       });
-      predictionsList.querySelectorAll('.add-actual').forEach(btn => {
+      predictionsList.querySelectorAll('.save-actual').forEach(btn => {
         btn.addEventListener('click', () => {
           const id = btn.getAttribute('data-id');
-          const val = prompt('Enter your actual results');
-          if (val){
-            const uid = auth.currentUser.uid;
-            db.collection('users').doc(uid).collection('predictions').doc(id).update({
-              actualResults: val,
-              updatedAt: firebase.firestore.FieldValue.serverTimestamp()
-            }).then(loadPredictions);
-          }
+          const li = btn.closest('li');
+          const input = li.querySelector('.actual-input');
+          const val = input.value.trim();
+          const uid = auth.currentUser.uid;
+          db.collection('users').doc(uid).collection('predictions').doc(id).update({
+            actualResults: val,
+            updatedAt: firebase.firestore.FieldValue.serverTimestamp()
+          }).then(loadPredictions);
         });
       });
     });


### PR DESCRIPTION
## Summary
- prevent cached pages from blocking updates by adding no-store meta tags and versioned script URLs
- replace prompt-based mock result entry with inline inputs to store actual mock results in Firestore

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3343d32548322b6aa6761eaaef6ec