### PR TITLE
fix: prevent index script hang

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,8 +9,8 @@
   <!-- Bootstrap 5 -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous"/>
 
-  <!-- Chart.js -->
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <!-- Chart.js (deferred so page doesn't block while loading) -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
 
   <style>
     :root{


### PR DESCRIPTION
## Summary
- defer Chart.js to avoid blocking page load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a336e707b083228a8f6a2788c643be