### PR TITLE
Revert results page and signup prompt

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -7,7 +7,11 @@
       console.error(msg);
     };
   
-    window.addEventListener('error', (e)=> showErr(e.message || e.error));
+    window.addEventListener('error', (e)=> {
+      // Ignore generic cross-origin "Script error." events without filename
+      if (e.message === 'Script error.' && !e.filename) return;
+      showErr(e.message || e.error);
+    });
     window.addEventListener('unhandledrejection', (e)=> showErr(e.reason || 'Unhandled promise rejection'));
   
     window.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- remove results page and sign-up prompt to return site to previous working state
- keep script-error suppression to avoid cross-origin failures
- narrow script-error suppression to ignore only generic cross-origin "Script error." messages without filenames

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a328200aa88322a78022f4fb3ff1eb