### PR TITLE
Remove ad banners while keeping margins

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,9 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <!-- TEMP: comment out AdSense while debugging
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7429797559685152" crossorigin="anonymous"></script>
-  -->
+  
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Points Probability Calculator — Wizard</title>
@@ -39,18 +37,9 @@
     .letter-filter{display:flex; flex-wrap:wrap; gap:4px; margin-top:.25rem;}
     .letter-filter button{border:none;background:#f1f3f5;padding:2px 6px;font-size:.8rem;cursor:pointer;}
     .letter-filter button.active{background:#ced4da;}
-    .ad-box{
-      background:#ffffff; border:1px solid var(--border); border-radius:.5rem;
-      min-height:600px; position:sticky; top:72px; display:flex; align-items:center; justify-content:center;
-      color:#6c757d; font-weight:600;
-    }
-    .ad-box .ad-inner{width:100%; height:100%; display:flex; align-items:center; justify-content:center; padding:8px;}
     .nav-actions .btn-lg{font-weight:600;}
     @media (max-width: 576px){
       .nav-actions .btn-lg{width:100%;}
-    }
-    @media (max-width: 991.98px){
-      .ad-box{position:relative; top:auto; min-height:120px; margin-bottom:1rem;}
     }
     /* Tiny error overlay */
     #errOverlay{position:fixed;left:0;right:0;bottom:0;z-index:9999;background:#fee;border-top:1px solid #f5c2c7;color:#842029;padding:.5rem 1rem;font-size:.9rem;display:none}
@@ -90,13 +79,11 @@
     </div>
   </nav>
 
-  <!-- LAYOUT: side ads + main -->
+  <!-- LAYOUT: main content with side margins -->
   <div class="container-fluid">
     <div class="row g-3">
-      <!-- Left ad (desktop) -->
-      <aside class="col-lg-2 d-none d-lg-block">
-        <div class="ad-box"><div class="ad-inner"><span>Ad Banner</span></div></div>
-      </aside>
+      <!-- Left margin (desktop) -->
+      <aside class="col-lg-2 d-none d-lg-block"></aside>
 
       <!-- Main content -->
       <main class="col-12 col-lg-8">
@@ -254,15 +241,8 @@
         </div>
       </main>
 
-      <!-- Right ad (desktop) -->
-      <aside class="col-lg-2 d-none d-lg-block">
-        <div class="ad-box"><div class="ad-inner"><span>Ad Banner</span></div></div>
-      </aside>
-
-      <!-- Mobile ad -->
-      <aside class="col-12 d-lg-none">
-        <div class="ad-box"><div class="ad-inner"><span>Ad Banner</span></div></div>
-      </aside>
+      <!-- Right margin (desktop) -->
+      <aside class="col-lg-2 d-none d-lg-block"></aside>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- Strip AdSense script and ad banner markup from main calculator layout.
- Replace side ad slots with empty columns to preserve existing margin widths.
- Clean up unused ad-related CSS.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3525f1d9483228a9569e5905c1ce3