### PR TITLE
Add subject dropdown and results page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,9 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <!-- TEMP: comment out AdSense while debugging
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7429797559685152" crossorigin="anonymous"></script>
-  -->
+  
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Points Probability Calculator — Wizard</title>
@@ -36,21 +34,9 @@
     .badge-chip{background:#f1f3f5; color:#495057; border:1px solid #e9ecef; border-radius:9999px; padding:0 .5rem; margin:.1rem; display:inline-block;}
     #histogram{max-height:420px;}
     .navbar-light{background:#ffffff; border-bottom:1px solid var(--border);}
-    .letter-filter{display:flex; flex-wrap:wrap; gap:4px; margin-top:.25rem;}
-    .letter-filter button{border:none;background:#f1f3f5;padding:2px 6px;font-size:.8rem;cursor:pointer;}
-    .letter-filter button.active{background:#ced4da;}
-    .ad-box{
-      background:#ffffff; border:1px solid var(--border); border-radius:.5rem;
-      min-height:600px; position:sticky; top:72px; display:flex; align-items:center; justify-content:center;
-      color:#6c757d; font-weight:600;
-    }
-    .ad-box .ad-inner{width:100%; height:100%; display:flex; align-items:center; justify-content:center; padding:8px;}
     .nav-actions .btn-lg{font-weight:600;}
     @media (max-width: 576px){
       .nav-actions .btn-lg{width:100%;}
-    }
-    @media (max-width: 991.98px){
-      .ad-box{position:relative; top:auto; min-height:120px; margin-bottom:1rem;}
     }
     /* Tiny error overlay */
     #errOverlay{position:fixed;left:0;right:0;bottom:0;z-index:9999;background:#fee;border-top:1px solid #f5c2c7;color:#842029;padding:.5rem 1rem;font-size:.9rem;display:none}
@@ -86,17 +72,16 @@
       <div class="d-flex align-items-center gap-3">
         <a class="text-muted text-decoration-none" href="#">About</a>
         <a class="text-muted text-decoration-none" href="#">Privacy</a>
+        <a class="text-muted text-decoration-none" href="results.html">Results</a>
       </div>
     </div>
   </nav>
 
-  <!-- LAYOUT: side ads + main -->
+  <!-- LAYOUT: main content with side margins -->
   <div class="container-fluid">
     <div class="row g-3">
-      <!-- Left ad (desktop) -->
-      <aside class="col-lg-2 d-none d-lg-block">
-        <div class="ad-box"><div class="ad-inner"><span>Ad Banner</span></div></div>
-      </aside>
+      <!-- Left margin (desktop) -->
+      <aside class="col-lg-2 d-none d-lg-block"></aside>
 
       <!-- Main content -->
       <main class="col-12 col-lg-8">
@@ -113,7 +98,7 @@
                 <input id="school" class="form-control mx-auto" style="max-width:300px" placeholder="Type your school">
               </div>
             </div>
-            <p class="text-muted mt-2 mb-0">Tap a grade (H1–H8 or O1–O8), then set its probability with the % grid or enter it manually below. The bar fills to 100%. Maths bonus applies only for <b>Higher</b>, and only one subject can be Maths.</p>
+            <p class="text-muted mt-2 mb-0">Tap a grade (H1–H8 or O1–O8), then set its probability with the % grid or enter it manually below. The bar fills to 100%. Maths bonus applies only for <b>Higher</b> Mathematics.</p>
           </header>
 
           <!-- Wizard Card -->
@@ -131,25 +116,18 @@
                 <div class="col-12">
                   <div id="subjectCard" class="p-3 rounded" style="background:#fff; border:1px solid var(--border);">
                     <div class="row g-3">
-                      <div class="col-12 col-md-7">
+                      <div class="col-12 col-md-8">
                         <label class="form-label">Subject Name</label>
-                        <input id="subName" class="form-control" list="subjectList" placeholder="">
-                        <datalist id="subjectList"></datalist>
-                        <div id="subjectLetters" class="letter-filter"></div>
+                        <select id="subName" class="form-select">
+                          <option value="">Select subject</option>
+                        </select>
                       </div>
-                      <div class="col-6 col-md-3">
+                      <div class="col-12 col-md-4">
                         <label class="form-label">Level</label>
                         <select id="subLevel" class="form-select">
                           <option value="Higher" selected>Higher</option>
                           <option value="Ordinary">Ordinary</option>
                         </select>
-                      </div>
-                      <div class="col-6 col-md-2 d-flex align-items-end">
-                        <div class="form-check">
-                          <input id="subMaths" type="checkbox" class="form-check-input">
-                          <label for="subMaths" class="form-check-label">Maths?</label>
-                          <div id="mathsLockHint" class="form-text d-none">Maths already set for another subject.</div>
-                        </div>
                       </div>
 
                       <!-- Grade pills -->
@@ -254,15 +232,8 @@
         </div>
       </main>
 
-      <!-- Right ad (desktop) -->
-      <aside class="col-lg-2 d-none d-lg-block">
-        <div class="ad-box"><div class="ad-inner"><span>Ad Banner</span></div></div>
-      </aside>
-
-      <!-- Mobile ad -->
-      <aside class="col-12 d-lg-none">
-        <div class="ad-box"><div class="ad-inner"><span>Ad Banner</span></div></div>
-      </aside>
+      <!-- Right margin (desktop) -->
+      <aside class="col-lg-2 d-none d-lg-block"></aside>
     </div>
   </div>
 

--- a/public/results.html
+++ b/public/results.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Results</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous"/>
+</head>
+<body>
+  <nav class="navbar navbar-light sticky-top">
+    <div class="container-fluid">
+      <a class="navbar-brand fw-semibold" href="index.html" style="color:#333;">LC Points</a>
+    </div>
+  </nav>
+  <div class="container py-4">
+    <h1 class="h4 mb-3">Results</h1>
+    <p>Your results will appear here.</p>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Replace subject text input with dropdown and auto-detect Mathematics for bonus points
- Remove manual Maths checkbox and adjust wizard logic accordingly
- Introduce placeholder results page and navigation link

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3525f1d9483228a9569e5905c1ce3