### PR TITLE
Require subjects from list and add about/privacy pages

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>About - LC Points</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+</head>
+<body class="bg-light">
+  <div class="container py-5">
+    <h1 class="h3 mb-3">About</h1>
+    <p>LC Points helps students estimate their probability of achieving a target Leaving Cert score based on subject grades.</p>
+    <p>For questions or feedback, contact <a href="mailto:iamharryashton@gmail.com">iamharryashton@gmail.com</a>.</p>
+    <a href="index.html">Back to calculator</a>
+  </div>
+</body>
+</html>
+

--- a/public/app.js
+++ b/public/app.js
@@ -42,7 +42,6 @@
         const selectionNote = Q('selectionNote');
         const resultsEl = Q('results');
         const histCanvas = Q('histogram');
-        const subjectListEl = Q('subjectList');
         const subjectLetters = Q('subjectLetters');
         const schoolListEl = Q('schoolList');
         const schoolLetters = Q('schoolLetters');
@@ -59,9 +58,16 @@
         // Datalist helpers
         const renderOptions = (dl, opts) => {
           dl.innerHTML = '';
+          if (dl.tagName === 'SELECT'){
+            const placeholder = document.createElement('option');
+            placeholder.value = '';
+            placeholder.textContent = 'Select subject';
+            dl.appendChild(placeholder);
+          }
           opts.forEach(name => {
             const opt = document.createElement('option');
             opt.value = name;
+            opt.textContent = name;
             dl.appendChild(opt);
           });
         };
@@ -90,8 +96,8 @@
         let subjectOptions = [];
         fetch('subjects.json').then(r=>r.json()).then(list=>{
           subjectOptions = list;
-          renderOptions(subjectListEl, list);
-          initLetterFilter(subjectLetters, list, subjectListEl);
+          renderOptions(subName, list);
+          initLetterFilter(subjectLetters, list, subName);
         });
 
         let schoolOptions = [];
@@ -191,7 +197,6 @@
   
           const s = subjects[current];
           subName.value = s.name;
-          subName.placeholder = `Enter subject ${current+1}`;
           subLevel.value = s.level;
   
           // Maths single-select
@@ -215,10 +220,10 @@
           };
   
           // name/level
-          subName.oninput = ()=> {
+          subName.onchange = ()=> {
             const val = subName.value.trim();
             subjects[current].name = val;
-            if (subjectOptions.length && !subjectOptions.includes(val)) {
+            if (!val || (subjectOptions.length && !subjectOptions.includes(val))) {
               subName.setCustomValidity('Choose a subject from the list');
             } else {
               subName.setCustomValidity('');
@@ -252,13 +257,13 @@
         function saveFromUI(){
           const s = subjects[current];
           const val = subName.value.trim();
-          if (subjectOptions.length && !subjectOptions.includes(val)) {
+          if (!val || (subjectOptions.length && !subjectOptions.includes(val))) {
             subName.setCustomValidity('Choose a subject from the list');
             subName.reportValidity();
             s.name = `Subject ${current+1}`;
           } else {
             subName.setCustomValidity('');
-            s.name = val || `Subject ${current+1}`;
+            s.name = val;
           }
           s.level = subLevel.value;
         }

--- a/public/index.html
+++ b/public/index.html
@@ -62,8 +62,8 @@
     <div class="container-fluid">
       <a class="navbar-brand fw-semibold" href="#" style="color:#333;">LC Points</a>
       <div class="d-flex align-items-center gap-3">
-        <a class="text-muted text-decoration-none" href="#">About</a>
-        <a class="text-muted text-decoration-none" href="#">Privacy</a>
+        <a class="text-muted text-decoration-none" href="about.html">About</a>
+        <a class="text-muted text-decoration-none" href="privacy.html">Privacy</a>
       </div>
     </div>
   </nav>
@@ -113,8 +113,7 @@
                     <div class="row g-3">
                       <div class="col-12 col-md-7">
                         <label class="form-label">Subject Name</label>
-                        <input id="subName" class="form-control" list="subjectList" placeholder="">
-                        <datalist id="subjectList"></datalist>
+                        <select id="subName" class="form-select"></select>
                         <div id="subjectLetters" class="letter-filter"></div>
                       </div>
                       <div class="col-6 col-md-3">

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Privacy - LC Points</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+</head>
+<body class="bg-light">
+  <div class="container py-5">
+    <h1 class="h3 mb-3">Privacy</h1>
+    <p>This calculator stores your entries locally in your browser and does not retain personal data on our servers.</p>
+    <p>If you have any privacy questions, contact <a href="mailto:iamharryashton@gmail.com">iamharryashton@gmail.com</a>.</p>
+    <a href="index.html">Back to calculator</a>
+  </div>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- Force subject selection from predefined subjects list via dropdown
- Add About and Privacy pages with contact email

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a35ab2291c832296bc5ec7497beda6