### PR TITLE
Store expected subject grades with timestamped IDs and verify Firebase writes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -118,9 +118,8 @@
                     <div class="row g-3">
                       <div class="col-12 col-md-8">
                         <label class="form-label">Subject Name</label>
-                        <select id="subName" class="form-select">
-                          <option value="">Select subject</option>
-                        </select>
+                        <input id="subName" class="form-control" list="subjectsList" placeholder="Start typing subject" required>
+                        <datalist id="subjectsList"></datalist>
                       </div>
                       <div class="col-12 col-md-4">
                         <label class="form-label">Level</label>


### PR DESCRIPTION
## Summary
- Save predictions using timestamp + school name as document ID, verifying the write in Firestore.
- Require school name input and store each subject's expected grade instead of probability arrays.
- Populate the subject field from `subjects.json` and filter suggestions as the user types.
- Keep suggestions visible while typing and enforce that subject names match the predefined list.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a38588bcd88322b256465458252873