### PR TITLE
fix: restore subject suggestions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -118,9 +118,6 @@
                     <div class="row g-3">
                       <div class="col-12 col-md-8">
                         <label class="form-label">Subject Name</label>
-                        <select id="subName" class="form-select">
-                          <option value="">Select subject</option>
-                        </select>
                         <input id="subName" class="form-control" list="subjectsList" placeholder="Start typing subject" required>
                         <datalist id="subjectsList"></datalist>
                       </div>


### PR DESCRIPTION
## Summary
- remove duplicate subject select control so datalist suggestions appear when typing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a38d0447cc832294cb54cfafff005d