### PR TITLE
fix: restore subject suggestions

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -82,17 +82,11 @@
         
         
         let allSubjects = [];
-        function updateSubjectOptions(filter){
+        function populateSubjectOptions(){
           subjectsList.innerHTML = '';
-          const f = filter.toLowerCase();
           allSubjects
-            .filter(name => name.toLowerCase().includes(f))
-            .sort((a,b)=>{
-              const aStarts = a.toLowerCase().startsWith(f);
-              const bStarts = b.toLowerCase().startsWith(f);
-              if (aStarts === bStarts) return a.localeCompare(b);
-              return aStarts ? -1 : 1;
-            })
+            .slice()
+            .sort((a,b)=>a.localeCompare(b))
             .forEach(name => {
               const opt = document.createElement('option');
               opt.value = name;
@@ -101,7 +95,7 @@
         }
         fetch('subjects.json').then(r=>r.json()).then(list=>{
           allSubjects = list;
-          updateSubjectOptions('');
+          populateSubjectOptions();
         });
 
         function isValidSubject(name){
@@ -227,11 +221,10 @@
           s.isMaths = (s.name === 'Mathematics');
           subName.value = s.name;
           subLevel.value = s.level;
-          updateSubjectOptions(subName.value);
 
-          subName.oninput = ()=> {
-            updateSubjectOptions(subName.value);
-          };
+          // Ensure options are present for the datalist
+          if (!subjectsList.children.length) populateSubjectOptions();
+
           subName.onchange = ()=> {
             const val = subName.value;
             subjects[current].name = val;

--- a/public/index.html
+++ b/public/index.html
@@ -118,9 +118,6 @@
                     <div class="row g-3">
                       <div class="col-12 col-md-8">
                         <label class="form-label">Subject Name</label>
-                        <select id="subName" class="form-select">
-                          <option value="">Select subject</option>
-                        </select>
                         <input id="subName" class="form-control" list="subjectsList" placeholder="Start typing subject" required>
                         <datalist id="subjectsList"></datalist>
                       </div>


### PR DESCRIPTION
## Summary
- preload all subject names into the datalist so browser suggestions show as you type
- ensure the datalist is available whenever the wizard rerenders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a38d0447cc832294cb54cfafff005d