### PR TITLE
Add filterable subject dropdown

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -23,7 +23,7 @@
         const stepNow = Q('stepNow');
         const stepTotal = Q('stepTotal');
         const subName = Q('subName');
-        const subjectsList = Q('subjectsList');
+        const subFilter = Q('subFilter');
         const subLevel = Q('subLevel');
         const gradePills = Q('gradePills');
         const remainingLabel = Q('remainingLabel');
@@ -82,26 +82,29 @@
         
         
         let allSubjects = [];
-        function updateSubjectOptions(filter){
-          subjectsList.innerHTML = '';
-          const f = filter.toLowerCase();
+        function populateSubjectOptions(){
+          subName.innerHTML = '<option value="">Select subject</option>';
           allSubjects
-            .filter(name => name.toLowerCase().includes(f))
-            .sort((a,b)=>{
-              const aStarts = a.toLowerCase().startsWith(f);
-              const bStarts = b.toLowerCase().startsWith(f);
-              if (aStarts === bStarts) return a.localeCompare(b);
-              return aStarts ? -1 : 1;
-            })
+            .slice()
+            .sort((a,b)=>a.localeCompare(b))
             .forEach(name => {
               const opt = document.createElement('option');
               opt.value = name;
-              subjectsList.appendChild(opt);
+              opt.textContent = name;
+              subName.appendChild(opt);
             });
         }
         fetch('subjects.json').then(r=>r.json()).then(list=>{
           allSubjects = list;
-          updateSubjectOptions('');
+          populateSubjectOptions();
+        });
+
+        subFilter.addEventListener('input', ()=>{
+          const f = subFilter.value.toLowerCase();
+          Array.from(subName.options).forEach(opt=>{
+            if (!opt.value) return;
+            opt.hidden = !opt.textContent.toLowerCase().includes(f);
+          });
         });
 
         function isValidSubject(name){
@@ -227,11 +230,11 @@
           s.isMaths = (s.name === 'Mathematics');
           subName.value = s.name;
           subLevel.value = s.level;
-          updateSubjectOptions(subName.value);
 
-          subName.oninput = ()=> {
-            updateSubjectOptions(subName.value);
-          };
+          // Reset filter and ensure options shown
+          subFilter.value = '';
+          subFilter.dispatchEvent(new Event('input'));
+
           subName.onchange = ()=> {
             const val = subName.value;
             subjects[current].name = val;

--- a/public/index.html
+++ b/public/index.html
@@ -118,11 +118,8 @@
                     <div class="row g-3">
                       <div class="col-12 col-md-8">
                         <label class="form-label">Subject Name</label>
-                        <select id="subName" class="form-select">
-                          <option value="">Select subject</option>
-                        </select>
-                        <input id="subName" class="form-control" list="subjectsList" placeholder="Start typing subject" required>
-                        <datalist id="subjectsList"></datalist>
+                        <input id="subFilter" class="form-control mb-2" placeholder="Type to filter subjects">
+                        <select id="subName" class="form-select" required></select>
                       </div>
                       <div class="col-12 col-md-4">
                         <label class="form-label">Level</label>


### PR DESCRIPTION
## Summary
- Replace datalist with dropdown select populated from `subjects.json`
- Allow users to type in a filter box to narrow the subject list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a38d0447cc832294cb54cfafff005d