### PR TITLE
Use datalist for subject entry

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -23,7 +23,7 @@
         const stepNow = Q('stepNow');
         const stepTotal = Q('stepTotal');
         const subName = Q('subName');
-        const subjectsList = Q('subjectsList');
+        const subList = Q('subjectOptions');
         const subLevel = Q('subLevel');
         const gradePills = Q('gradePills');
         const remainingLabel = Q('remainingLabel');
@@ -82,26 +82,20 @@
         
         
         let allSubjects = [];
-        function updateSubjectOptions(filter){
-          subjectsList.innerHTML = '';
-          const f = filter.toLowerCase();
+        function populateSubjectOptions(){
+          subList.innerHTML = '';
           allSubjects
-            .filter(name => name.toLowerCase().includes(f))
-            .sort((a,b)=>{
-              const aStarts = a.toLowerCase().startsWith(f);
-              const bStarts = b.toLowerCase().startsWith(f);
-              if (aStarts === bStarts) return a.localeCompare(b);
-              return aStarts ? -1 : 1;
-            })
+            .slice()
+            .sort((a,b)=>a.localeCompare(b))
             .forEach(name => {
               const opt = document.createElement('option');
               opt.value = name;
-              subjectsList.appendChild(opt);
+              subList.appendChild(opt);
             });
         }
         fetch('subjects.json').then(r=>r.json()).then(list=>{
           allSubjects = list;
-          updateSubjectOptions('');
+          populateSubjectOptions();
         });
 
         function isValidSubject(name){
@@ -227,12 +221,8 @@
           s.isMaths = (s.name === 'Mathematics');
           subName.value = s.name;
           subLevel.value = s.level;
-          updateSubjectOptions(subName.value);
 
           subName.oninput = ()=> {
-            updateSubjectOptions(subName.value);
-          };
-          subName.onchange = ()=> {
             const val = subName.value;
             subjects[current].name = val;
             subjects[current].isMaths = (val === 'Mathematics');

--- a/public/index.html
+++ b/public/index.html
@@ -118,11 +118,8 @@
                     <div class="row g-3">
                       <div class="col-12 col-md-8">
                         <label class="form-label">Subject Name</label>
-                        <select id="subName" class="form-select">
-                          <option value="">Select subject</option>
-                        </select>
-                        <input id="subName" class="form-control" list="subjectsList" placeholder="Start typing subject" required>
-                        <datalist id="subjectsList"></datalist>
+                        <input id="subName" list="subjectOptions" class="form-control" placeholder="Type to filter subjects" required>
+                        <datalist id="subjectOptions"></datalist>
                       </div>
                       <div class="col-12 col-md-4">
                         <label class="form-label">Level</label>


### PR DESCRIPTION
## Summary
- Replace separate filter input and select with a single datalist-backed field
- Populate datalist from `subjects.json` and update subject model as user types

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a38d0447cc832294cb54cfafff005d