### PR TITLE
feat: add filterable subject dropdown

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -23,7 +23,7 @@
         const stepNow = Q('stepNow');
         const stepTotal = Q('stepTotal');
         const subName = Q('subName');
-        const subFilter = Q('subFilter');
+        const subjectList = Q('subjectsList');
         const subLevel = Q('subLevel');
         const gradePills = Q('gradePills');
         const remainingLabel = Q('remainingLabel');
@@ -82,28 +82,19 @@
         
         let allSubjects = [];
         function populateSubjectOptions(){
-          subName.innerHTML = '<option value="">Select subject</option>';
+          subjectList.innerHTML = '';
           allSubjects
             .slice()
             .sort((a,b)=>a.localeCompare(b))
             .forEach(name => {
               const opt = document.createElement('option');
               opt.value = name;
-              opt.textContent = name;
-              subName.appendChild(opt);
+              subjectList.appendChild(opt);
             });
         }
         fetch('subjects.json').then(r=>r.json()).then(list=>{
           allSubjects = list;
           populateSubjectOptions();
-        });
-
-        subFilter.addEventListener('input', ()=>{
-          const f = subFilter.value.toLowerCase();
-          Array.from(subName.options).forEach(opt=>{
-            if (!opt.value) return;
-            opt.hidden = !opt.textContent.toLowerCase().includes(f);
-          });
         });
 
         function isValidSubject(name){
@@ -230,11 +221,7 @@
           subName.value = s.name;
           subLevel.value = s.level;
         
-          // Reset filter and ensure options shown
-          subFilter.value = '';
-          subFilter.dispatchEvent(new Event('input'));
-
-          subName.onchange = ()=> {
+          subName.oninput = ()=> {
             const val = subName.value;
             subjects[current].name = val;
             subjects[current].isMaths = (val === 'Mathematics');

--- a/public/index.html
+++ b/public/index.html
@@ -118,8 +118,8 @@
                     <div class="row g-3">
                       <div class="col-12 col-md-8">
                         <label class="form-label">Subject Name</label>
-                        <input id="subFilter" class="form-control mb-2" placeholder="Type to filter subjects">
-                        <select id="subName" class="form-select" required></select>
+                        <input id="subName" class="form-control" list="subjectsList" placeholder="Start typing to choose a subject" required>
+                        <datalist id="subjectsList"></datalist>
                       </div>
                       <div class="col-12 col-md-4">
                         <label class="form-label">Level</label>


### PR DESCRIPTION
## Summary
- replace text filter with type-ahead subject input
- load subjects from subjects.json into datalist

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3b562c2488322acb81444e8cdd3e0