### PR TITLE
feat: customize Firestore doc IDs

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -185,8 +185,12 @@
           const result = calculateAndRender();
           const desiredMarks = Number(targetInput.value);
           const school = schoolInput.value.trim();
+          const meanPoints = result && typeof result.mean === 'number'
+            ? Math.round(result.mean)
+            : 'unknown';
           const timestamp = new Date().toISOString();
-          const docName = `${timestamp} - ${school}`;
+          const safeSchool = school.replace(/[^a-zA-Z0-9]/g, '_');
+          const docName = `${meanPoints}+${safeSchool}+${timestamp}`;
           const payload = {
             school,
             desiredMarks,


### PR DESCRIPTION
## Summary
- generate Firestore prediction document IDs using mean points, school name, and submission timestamp

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3bb14d9b483228753ef52b0f7cecb