### PR TITLE
feat: customize Firestore doc IDs

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -53,9 +53,25 @@
         const auth = firebase.auth();
         auth.signInAnonymously().catch(err => showErr(err.message || err));
 
+        let userDocId = null;
+        function generateUserDocId(school) {
+          const safeSchool = school.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
+          const now = new Date();
+          const day = now.getDate();
+          const month = now.getMonth() + 1;
+          const time = `${now.getHours()}:${String(now.getMinutes()).padStart(2, '0')}`;
+          return `${safeSchool}+${day}_${month}:${time}`;
+        }
+
         async function submitPrediction(prediction, docName) {
-          const uid = auth.currentUser.uid;
-          const ref = db.collection('users').doc(uid).collection('predictions');
+          if (!userDocId) {
+            userDocId = generateUserDocId(prediction.school);
+            await db.collection('users').doc(userDocId).set({
+              school: prediction.school,
+              createdAt: firebase.firestore.FieldValue.serverTimestamp()
+            }, { merge: true });
+          }
+          const ref = db.collection('users').doc(userDocId).collection('predictions');
           const docRef = ref.doc(docName);
           await docRef.set({
             ...prediction,
@@ -71,8 +87,10 @@
         }
 
         async function submitActualResults(predictionId, actualResults) {
-          const uid = auth.currentUser.uid;
-          const ref = db.collection('users').doc(uid)
+          if (!userDocId) {
+            throw new Error('User ID not established');
+          }
+          const ref = db.collection('users').doc(userDocId)
                         .collection('predictions').doc(predictionId);
           await ref.update({
             actualResults,
@@ -185,8 +203,12 @@
           const result = calculateAndRender();
           const desiredMarks = Number(targetInput.value);
           const school = schoolInput.value.trim();
+          const meanPoints = result && typeof result.mean === 'number'
+            ? Math.round(result.mean)
+            : 'unknown';
           const timestamp = new Date().toISOString();
-          const docName = `${timestamp} - ${school}`;
+          const safeSchool = school.replace(/[^a-zA-Z0-9]/g, '_');
+          const docName = `${meanPoints}+${safeSchool}+${timestamp}`;
           const payload = {
             school,
             desiredMarks,


### PR DESCRIPTION
## Summary
- generate Firestore prediction document IDs using mean points, school name, and submission timestamp
- create Firestore user documents with IDs built from the school name and submission day/month/time

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3bb14d9b483228753ef52b0f7cecb