### PR TITLE
Improve probability input and display

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -30,6 +30,7 @@
         const remainingBar = Q('remainingBar');
         const subjectCard = Q('subjectCard');
         const probInput = Q('probInput');
+        const subjectsDisplay = Q('subjectsDisplay');
         const prevBtn = Q('prevBtn');
         const nextBtn = Q('nextBtn');
         const addBtn = Q('addBtn');
@@ -248,18 +249,24 @@
           });
         });
 
-        Q('kpSet').onclick = ()=>{
+        function applyProbInput(){
           const v = Number(probInput.value);
           if (!Number.isFinite(v)) return;
           const asDec = Math.max(0, Math.min(1, (v>1)? v/100 : v));
           setGradeValue(asDec);
-        };
-        probInput.addEventListener('keydown', e=>{ if(e.key==='Enter') Q('kpSet').click(); });
+        }
+        probInput.addEventListener('change', applyProbInput);
+        probInput.addEventListener('keydown', e=>{ if(e.key==='Enter') applyProbInput(); });
   
         /* ====== Render Wizard ====== */
       function renderWizard(){
           stepNow.textContent = String(current+1);
           stepTotal.textContent = String(subjects.length);
+
+          subjectsDisplay.innerHTML = subjects
+            .filter(s=>s.name.trim())
+            .map(s=>`<span class="badge-chip">${s.name}</span>`)
+            .join('');
 
           const s = subjects[current];
           s.isMaths = (s.name === 'Mathematics');
@@ -407,6 +414,25 @@
           const stroke = getComputedStyle(document.documentElement).getPropertyValue('--accent-green-border').trim();
 
           const plugins = [];
+          if (Number.isFinite(mean)){
+            plugins.push({
+              id:'meanLine',
+              afterDraw(chart){
+                const xScale = chart.scales.x;
+                if (mean < xScale.min || mean > xScale.max) return;
+                const x = xScale.getPixelForValue(mean);
+                const ctx = chart.ctx;
+                ctx.save();
+                ctx.strokeStyle = 'green';
+                ctx.lineWidth = 2;
+                ctx.beginPath();
+                ctx.moveTo(x, chart.chartArea.top);
+                ctx.lineTo(x, chart.chartArea.bottom);
+                ctx.stroke();
+                ctx.restore();
+              }
+            });
+          }
           if (Number.isFinite(targetVal)){
             plugins.push({
               id:'targetLine',

--- a/public/index.html
+++ b/public/index.html
@@ -111,6 +111,7 @@
               <div class="text-muted small">Complete each subject to 100%.</div>
             </div>
             <div class="card-body">
+              <div id="subjectsDisplay" class="mb-3"></div>
               <div class="row g-4">
                 <!-- Subject meta + grades -->
                 <div class="col-12">
@@ -160,11 +161,7 @@
                   <label class="form-label">Set probability for the selected grade</label>
 
                   <div class="mb-3">
-                    <label for="probInput" class="form-label">Manual Probability</label>
-                    <div class="input-group">
-                      <input id="probInput" class="form-control" placeholder="e.g. 70 or 0.7">
-                      <button id="kpSet" class="btn btn-main" type="button">Set Value for Selected Grade</button>
-                    </div>
+                    <input id="probInput" class="form-control form-control-lg w-100" style="max-width:350px;" placeholder="e.g. 70 or 0.7">
                   </div>
 
                   <!-- Percent grid -->
@@ -223,6 +220,9 @@
                 <div class="card-header bg-white fw-semibold">Probability Distribution</div>
                 <div class="card-body">
                   <canvas id="histogram" height="340"></canvas>
+                </div>
+                <div class="card-footer small">
+                  <span class="text-success">Green</span> line: mean result. <span class="text-danger">Red</span> line: target points.
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Enlarge manual probability input and remove redundant controls
- Show entered subjects under the Subject Setup header
- Plot mean points as a green line and explain chart markers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3c4cafe74832293b9052c6d2ca3d0