### PR TITLE
Allow publishing predictions and show published results

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -210,6 +210,7 @@
           const timestamp = new Date().toISOString();
           const safeSchool = school.replace(/[^a-zA-Z0-9]/g, '_');
           const docName = `${meanPoints}+${safeSchool}+${timestamp}`;
+          const publish = window.confirm('Would you like to publish your results?');
           const payload = {
             school,
             desiredMarks,
@@ -218,8 +219,12 @@
               name: s.name,
               level: s.level,
               expected: s.expected
-            }))
+            })),
+            publish
           };
+          if (publish) {
+            payload.publishedAt = firebase.firestore.FieldValue.serverTimestamp();
+          }
           submitPrediction(payload, docName).catch(err => showErr(err.message || err));
         };
   

--- a/public/results.html
+++ b/public/results.html
@@ -19,8 +19,25 @@
   </nav>
   <div class="container py-4">
     <h1 class="h4 mb-3">Results</h1>
-    <p>Your results will appear here.</p>
+    <div class="table-responsive">
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th>School</th>
+            <th>Mean Points</th>
+            <th>Target Points</th>
+            <th>Published</th>
+          </tr>
+        </thead>
+        <tbody id="resultsBody">
+          <tr><td colspan="4" class="text-muted">Loading...</td></tr>
+        </tbody>
+      </table>
+    </div>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-firestore-compat.js"></script>
+  <script src="results.js" defer></script>
 </body>
 </html>

--- a/public/results.js
+++ b/public/results.js
@@ -1,0 +1,59 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const listBody = document.getElementById('resultsBody');
+
+  // Firebase setup (same config as app.js)
+  const firebaseConfig = {
+    apiKey: "AIzaSyAS5PvPMYQjCQz88drt1VG6B5Y2v3PpjZM",
+    authDomain: "lcpredic.firebaseapp.com",
+    projectId: "lcpredic"
+  };
+  if (!firebase.apps.length) {
+    firebase.initializeApp(firebaseConfig);
+  }
+  const db = firebase.firestore();
+
+  function colorFor(mean, target) {
+    if (!target || !mean) return '#000';
+    const ratio = mean / target;
+    if (ratio >= 1) {
+      const light = 40 + Math.min((ratio - 1) * 30, 30); // 40-70%
+      return `hsl(120, 70%, ${light}%)`;
+    } else {
+      const light = 70 - Math.min((1 - ratio) * 30, 30); // 40-70%
+      return `hsl(0, 70%, ${light}%)`;
+    }
+  }
+
+  try {
+    const snap = await db.collectionGroup('predictions')
+      .where('publish', '==', true)
+      .orderBy('publishedAt', 'desc')
+      .get();
+
+    listBody.innerHTML = '';
+    if (snap.empty) {
+      listBody.innerHTML = '<tr><td colspan="4" class="text-muted">No published results yet.</td></tr>';
+      return;
+    }
+
+    snap.forEach(doc => {
+      const data = doc.data();
+      const mean = data.meanMarks ? Number(data.meanMarks) : 0;
+      const target = data.desiredMarks ? Number(data.desiredMarks) : 0;
+      const colour = colorFor(mean, target);
+      const dateStr = data.publishedAt && data.publishedAt.toDate
+        ? data.publishedAt.toDate().toLocaleDateString()
+        : '';
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${data.school || ''}</td>
+        <td style="color:${colour}">${mean.toFixed(1)}</td>
+        <td style="color:${colour}">${target}</td>
+        <td>${dateStr}</td>
+      `;
+      listBody.appendChild(tr);
+    });
+  } catch (err) {
+    listBody.innerHTML = `<tr><td colspan="4" class="text-danger">${err.message || err}</td></tr>`;
+  }
+});


### PR DESCRIPTION
## Summary
- prompt users to publish their prediction and mark records accordingly
- add public results page listing most recent published predictions with color indicating mean vs target

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c76ba8248322ae6467cf4bb5e388