### PR TITLE
Use auth UID for user docs and restrict Firestore access

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,18 +1,11 @@
-rules_version='2'
-
+rules_version = '2';
 service cloud.firestore {
-  match /databases/{database}/documents {
-    match /{document=**} {
-      // This rule allows anyone with your database reference to view, edit,
-      // and delete all data in your database. It is useful for getting
-      // started, but it is configured to expire after 30 days because it
-      // leaves your app open to attackers. At that time, all client
-      // requests to your database will be denied.
-      //
-      // Make sure to write security rules for your app before that time, or
-      // else all client requests to your database will be denied until you
-      // update your rules.
-      allow read, write: if request.time < timestamp.date(2025, 9, 15);
+  match /databases/{db}/documents {
+    match /users/{userId}/predictions/{predictionId} {
+      allow write: if request.auth != null && request.auth.uid == userId;
+      allow read: if resource.data.publish == true ||
+                   (request.auth != null && request.auth.uid == userId);
     }
   }
 }
+


### PR DESCRIPTION
## Summary
- Use authenticated UID instead of custom IDs when saving predictions
- Restrict Firestore access so only owners can write and only published docs are readable

## Testing
- `npm test`
- `npx firebase-tools deploy --only firestore:rules` *(fails: Need to install packages / authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d37ccbdc832285390b890a2cd720