### PR TITLE
Cap points at 625 and restrict math entry

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -86,7 +86,7 @@
             <div class="d-flex flex-column align-items-center gap-2">
               <div>
                 <label class="form-label mb-0">Target Points</label>
-                <input id="target" type="number" class="form-control mx-auto" style="max-width:200px" placeholder="e.g. 500" required>
+                <input id="target" type="number" max="625" class="form-control mx-auto" style="max-width:200px" placeholder="e.g. 500" required>
               </div>
               <div>
                 <label class="form-label mb-0">School</label>

--- a/public/results.js
+++ b/public/results.js
@@ -7,6 +7,7 @@
   firebase.initializeApp(firebaseConfig);
   const db = firebase.firestore();
   const auth = firebase.auth();
+  const MAX_POINTS = 625;
 
   const authSection = document.getElementById('authSection');
   const resultsSection = document.getElementById('resultsSection');
@@ -35,6 +36,10 @@
         const actualVal = data.actualResults ? data.actualResults : '';
         li.innerHTML = `<div><strong>${data.desiredMarks ?? ''}</strong> points (mean ${data.meanMarks ?? ''}) - <small>${date}</small></div>` +
                        `<div class="mt-2 d-flex align-items-center gap-2"><input type="text" class="form-control form-control-sm actual-input" placeholder="Enter mock results" value="${actualVal}"><button class="btn btn-sm btn-outline-primary save-actual" data-id="${doc.id}">Save</button></div>`;
+        // Highlight entries that achieved the maximum predicted points
+        if ((data.meanMarks ?? 0) >= MAX_POINTS) {
+          li.classList.add('list-group-item-primary');
+        }
         predictionsList.appendChild(li);
       });
       predictionsList.querySelectorAll('.save-actual').forEach(btn => {


### PR DESCRIPTION
## Summary
- Enforce 625-point maximum and cap distributions
- Block duplicate Mathematics entries and normalize targets
- Highlight perfect 625-point predictions in results list

## Testing
- `npm test`
- `node --check public/app.js`
- `node --check public/results.js`


------
https://chatgpt.com/codex/tasks/task_e_68a3d60f4878832280df0648e7de7226