### PR TITLE
Allow prediction saves and public results

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -46,6 +46,15 @@
   //     ]
   //   },
   // ]
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "predictions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "publish", "mode": "ASCENDING" },
+        { "fieldPath": "publishedAt", "mode": "DESCENDING" }
+      ]
+    }
+  ],
   "fieldOverrides": []
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,11 +1,16 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{db}/documents {
-    match /users/{userId}/predictions/{predictionId} {
-      allow write: if request.auth != null && request.auth.uid == userId;
-      allow read: if resource.data.publish == true ||
-                   (request.auth != null && request.auth.uid == userId);
+    match /users/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+
+      match /predictions/{predictionId} {
+        allow write: if request.auth != null && request.auth.uid == userId;
+        allow read: if resource.data.publish == true ||
+                     (request.auth != null && request.auth.uid == userId);
+      }
     }
+
     match /{path=**}/predictions/{predictionId} {
       allow read: if resource.data.publish == true;
     }


### PR DESCRIPTION
## Summary
- permit authenticated users to store user docs and their prediction entries
- define index so published predictions can be listed by publish time

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a467d914d08322ad36bc42f258bcd8