### PR TITLE
Color-code results by mean/target ratio

### DIFF
--- a/public/results.js
+++ b/public/results.js
@@ -13,14 +13,17 @@ document.addEventListener('DOMContentLoaded', async () => {
   const db = firebase.firestore();
 
   function colorFor(mean, target) {
-    if (!target || !mean) return '#000';
+    if (!target || !mean) return '#6c757d';
     const ratio = mean / target;
-    if (ratio <= 1) {
-      return 'hsl(120, 70%, 30%)'; // deepest green
-    } else {
-      const light = 40 + Math.min((ratio - 1) * 30, 30); // 40-70%
-      return `hsl(0, 70%, ${light}%)`;
+    if (ratio >= 1) {
+      const light = 45 - Math.min((ratio - 1) * 25, 25); // deepen with ratio
+      return `hsl(120, 70%, ${light}%)`;
     }
+    if (ratio >= 0.9) {
+      return '#6c757d'; // within 10% below target
+    }
+    const light = 50 - Math.min((0.9 - ratio) * 100, 25); // deepen red as ratio drops
+    return `hsl(0, 70%, ${light}%)`;
   }
 
   try {
@@ -43,8 +46,8 @@ document.addEventListener('DOMContentLoaded', async () => {
       const tr = document.createElement('tr');
       tr.innerHTML = `
         <td>${data.school || ''}</td>
-        <td style="color:${colour}">${mean.toFixed(1)}</td>
-        <td style="color:${colour}">${target}</td>
+        <td class="fw-bold" style="color:${colour}">${mean.toFixed(1)}</td>
+        <td class="fw-bold" style="color:${colour}">${target}</td>
       `;
       listBody.appendChild(tr);
     });


### PR DESCRIPTION
## Summary
- Scale mean & target text color to green when meeting/exceeding targets
- Show grey when mean falls within 10% under target, red when more than 10% behind
- Bold mean and target values for emphasis

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a46b91cd608322ace5d495ef9af096