### PR TITLE
Add link to view other schools' scores after publishing

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -222,7 +222,7 @@
           }
           submitPrediction(payload, docName).catch(err => showErr(err.message || err));
           const linkEl = document.getElementById('resultsLink');
-          if (linkEl) linkEl.style.display = 'block';
+          if (publish && linkEl) linkEl.style.display = 'block';
         };
   
         targetInput.addEventListener('input', ()=>{

--- a/public/index.html
+++ b/public/index.html
@@ -206,7 +206,7 @@
             </div>
           </div>
           <div id="resultsLink" class="text-center mb-3" style="display:none;">
-            <a href="results.html">View Published Results</a>
+            <a href="results.html">See how other schools are scoring</a>
           </div>
 
           <div class="row g-3">


### PR DESCRIPTION
## Summary
- After finishing and choosing to publish results, display a link inviting users to see how other schools are scoring.
- Update link text to "See how other schools are scoring" linking to results page.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a46c3914888322810cc2adcf808a13