### PR TITLE
Record probability of meeting target points

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -180,6 +180,7 @@
             school,
             desiredMarks,
             meanMarks: result ? result.mean : null,
+            targetProbability: result ? result.pGE : null,
             subjects: subjects.map(s => ({
               name: s.name,
               level: s.level,
@@ -442,7 +443,7 @@
             </div>
           `;
           drawHistogram(dist, mean, stdDev);
-          return {mean, stdDev};
+          return {mean, stdDev, pGE};
         }
   
         // expose for debug if you like

--- a/public/results.js
+++ b/public/results.js
@@ -34,7 +34,8 @@
         li.className = 'list-group-item';
         const date = data.createdAt && data.createdAt.toDate ? data.createdAt.toDate().toLocaleDateString() : 'unknown';
         const actualVal = data.actualResults ? data.actualResults : '';
-        li.innerHTML = `<div><strong>${data.desiredMarks ?? ''}</strong> points (mean ${data.meanMarks ?? ''}) - <small>${date}</small></div>` +
+        const probText = data.targetProbability != null ? `, chance ${(data.targetProbability * 100).toFixed(2)}%` : '';
+        li.innerHTML = `<div><strong>${data.desiredMarks ?? ''}</strong> points (mean ${data.meanMarks ?? ''}${probText}) - <small>${date}</small></div>` +
                        `<div class="mt-2 d-flex align-items-center gap-2"><input type="text" class="form-control form-control-sm actual-input" placeholder="Enter mock results" value="${actualVal}"><button class="btn btn-sm btn-outline-primary save-actual" data-id="${doc.id}">Save</button></div>`;
         // Highlight entries that achieved the maximum predicted points
         if ((data.meanMarks ?? 0) >= MAX_POINTS) {


### PR DESCRIPTION
## Summary
- Return target-point probability from calculation routine
- Save target probability with user prediction submissions
- Show chance of meeting target points in results list

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a46f0faf58832295519e689aa20359