### PR TITLE
Record target score likelihood

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -202,6 +202,9 @@
           const meanPoints = result && typeof result.mean === 'number'
             ? Math.round(result.mean)
             : 'unknown';
+          const probTarget = result && typeof result.pGE === 'number'
+            ? result.pGE
+            : null;
           const timestamp = new Date().toISOString();
           const safeSchool = school.replace(/[^a-zA-Z0-9]/g, '_');
           const docName = `${meanPoints}+${safeSchool}+${timestamp}`;
@@ -215,7 +218,8 @@
               level: s.level,
               expected: s.expected
             })),
-            publish
+            publish,
+            targetProbability: probTarget
           };
           if (publish) {
             payload.publishedAt = firebase.firestore.FieldValue.serverTimestamp();
@@ -503,7 +507,7 @@
             </div>
           `;
           drawHistogram(dist, mean, stdDev, targetVal);
-          return {mean, stdDev};
+          return {mean, stdDev, pGE};
         }
   
         // Initial render


### PR DESCRIPTION
## Summary
- Capture probability of meeting target points when finishing the wizard.
- Store this likelihood in Firestore via `targetProbability` field.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a478b67c808322ac72442edb805bde