### PR TITLE
Highlight low target scores on results page

### DIFF
--- a/public/results.js
+++ b/public/results.js
@@ -14,6 +14,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   function colorFor(mean, target) {
     if (!target || !mean) return '#6c757d';
+    if (target < mean) return '#dc3545';
     const ratio = mean / target;
     if (ratio >= 1) {
       const light = 45 - Math.min((ratio - 1) * 25, 25); // deepen with ratio


### PR DESCRIPTION
## Summary
- Mark mean and target values red when a user's target score is lower than their mean score

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a47c4d20c88322b7f71d685c445e43