### PR TITLE
Add sortable results table with date column

### DIFF
--- a/public/results.html
+++ b/public/results.html
@@ -23,13 +23,14 @@
       <table class="table table-striped">
         <thead>
           <tr>
-            <th>School</th>
-            <th>Mean Points</th>
-            <th>Target Points</th>
+            <th data-sort="school">School</th>
+            <th data-sort="mean">Mean Points</th>
+            <th data-sort="target">Target Points</th>
+            <th data-sort="createdAt">Date Added</th>
           </tr>
         </thead>
         <tbody id="resultsBody">
-          <tr><td colspan="3" class="text-muted">Loading...</td></tr>
+          <tr><td colspan="4" class="text-muted">Loading...</td></tr>
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
## Summary
- show date added for each result and enable sorting by any column
- default results to most recent and toggle order with column headers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a48662e8048322aec01f954ab5b552