### PR TITLE
Add analytics page for top schools and subjects

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -14,6 +14,7 @@
         <a class="text-muted text-decoration-none" href="about.html">About</a>
         <a class="text-muted text-decoration-none" href="privacy.html">Privacy</a>
         <a class="text-muted text-decoration-none" href="results.html">Results</a>
+        <a class="text-muted text-decoration-none" href="analytics.html">Analytics</a>
       </div>
     </div>
   </nav>

--- a/public/analytics.html
+++ b/public/analytics.html
@@ -2,10 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7429797559685152"
-     crossorigin="anonymous"></script>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Privacy</title>
+  <title>Analytics</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous"/>
 </head>
 <body>
@@ -21,10 +19,21 @@
     </div>
   </nav>
   <div class="container py-4">
-    <h1 class="h4 mb-3">Privacy</h1>
-    <p>This app stores your subject predictions anonymously in Google Firestore to calculate points probabilities.</p>
-    <p>Each prediction record includes your school name, target points, calculated mean, and expected points for each subject.</p>
-    <p>Source code is available on <a href="https://github.com/iamharryashton/predictor" target="_blank" rel="noopener">GitHub</a>. For privacy questions, contact <a href="mailto:iamharryashton@gmail.com">iamharryashton@gmail.com</a>.</p>
+    <h1 class="h4 mb-3">Analytics</h1>
+    <div class="row">
+      <div class="col-md-6 mb-4">
+        <h2 class="h5">Top Schools by Mean Points</h2>
+        <ol id="schoolList"><li class="text-muted">Loading...</li></ol>
+      </div>
+      <div class="col-md-6 mb-4">
+        <h2 class="h5">Top Subjects by Average Points</h2>
+        <ol id="subjectList"><li class="text-muted">Loading...</li></ol>
+      </div>
+    </div>
   </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-firestore-compat.js"></script>
+  <script src="analytics.js" defer></script>
 </body>
 </html>

--- a/public/analytics.js
+++ b/public/analytics.js
@@ -1,0 +1,80 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const schoolList = document.getElementById('schoolList');
+  const subjectList = document.getElementById('subjectList');
+
+  const firebaseConfig = {
+    apiKey: "AIzaSyAS5PvPMYQjCQz88drt1VG6B5Y2v3PpjZM",
+    authDomain: "lcpredic.firebaseapp.com",
+    projectId: "lcpredic"
+  };
+  if (!firebase.apps.length) {
+    firebase.initializeApp(firebaseConfig);
+  }
+  const db = firebase.firestore();
+
+  try {
+    const snap = await db.collectionGroup('predictions')
+      .where('publish', '==', true)
+      .get();
+
+    const schoolStats = new Map();
+    const subjectStats = new Map();
+
+    snap.forEach(doc => {
+      const data = doc.data();
+      const mean = typeof data.meanMarks === 'number' ? data.meanMarks : null;
+      const school = data.school;
+      if (school && mean !== null) {
+        const entry = schoolStats.get(school) || { total: 0, count: 0 };
+        entry.total += mean;
+        entry.count += 1;
+        schoolStats.set(school, entry);
+      }
+      if (Array.isArray(data.subjects)) {
+        data.subjects.forEach(sub => {
+          if (!sub || typeof sub.expected !== 'number' || !sub.name) return;
+          const sEntry = subjectStats.get(sub.name) || { total: 0, count: 0 };
+          sEntry.total += sub.expected;
+          sEntry.count += 1;
+          subjectStats.set(sub.name, sEntry);
+        });
+      }
+    });
+
+    const schools = Array.from(schoolStats.entries())
+      .map(([school, { total, count }]) => ({ school, avg: total / count }))
+      .sort((a, b) => b.avg - a.avg)
+      .slice(0, 5);
+
+    const subjects = Array.from(subjectStats.entries())
+      .map(([name, { total, count }]) => ({ name, avg: total / count }))
+      .sort((a, b) => b.avg - a.avg)
+      .slice(0, 5);
+
+    schoolList.innerHTML = '';
+    if (schools.length === 0) {
+      schoolList.innerHTML = '<li class="text-muted">No data</li>';
+    } else {
+      schools.forEach(({ school, avg }) => {
+        const li = document.createElement('li');
+        li.textContent = `${school} – ${avg.toFixed(1)}`;
+        schoolList.appendChild(li);
+      });
+    }
+
+    subjectList.innerHTML = '';
+    if (subjects.length === 0) {
+      subjectList.innerHTML = '<li class="text-muted">No data</li>';
+    } else {
+      subjects.forEach(({ name, avg }) => {
+        const li = document.createElement('li');
+        li.textContent = `${name} – ${avg.toFixed(1)}`;
+        subjectList.appendChild(li);
+      });
+    }
+  } catch (err) {
+    const msg = err.message || String(err);
+    schoolList.innerHTML = `<li class="text-danger">${msg}</li>`;
+    subjectList.innerHTML = `<li class="text-danger">${msg}</li>`;
+  }
+});

--- a/public/index.html
+++ b/public/index.html
@@ -75,6 +75,7 @@
         <a class="text-muted text-decoration-none" href="about.html">About</a>
         <a class="text-muted text-decoration-none" href="privacy.html">Privacy</a>
         <a class="text-muted text-decoration-none" href="results.html">Results</a>
+        <a class="text-muted text-decoration-none" href="analytics.html">Analytics</a>
       </div>
     </div>
   </nav>

--- a/public/results.html
+++ b/public/results.html
@@ -14,6 +14,7 @@
         <a class="text-muted text-decoration-none" href="about.html">About</a>
         <a class="text-muted text-decoration-none" href="privacy.html">Privacy</a>
         <a class="text-muted text-decoration-none" href="results.html">Results</a>
+        <a class="text-muted text-decoration-none" href="analytics.html">Analytics</a>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
## Summary
- add analytics page showing top schools by mean points and top subjects by average points
- include Firestore-backed script to aggregate and display rankings
- link to new analytics page from site navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4884d1a648322a75692e4aa7215d0