### PR TITLE
Add SEO metadata and sitemap

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -3,7 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>About</title>
+  <meta name="description" content="Learn about LC Points, an open-source Leaving Cert points probability calculator." />
+  <meta name="keywords" content="About LC Points, Leaving Cert points calculator, points probabilities" />
+  <meta name="robots" content="index, follow" />
+  <title>About LC Points</title>
+  <meta property="og:title" content="About LC Points" />
+  <meta property="og:description" content="Information about the Leaving Cert points calculator project." />
+  <meta property="og:type" content="website" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous"/>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7429797559685152"
      crossorigin="anonymous"></script>

--- a/public/analytics.html
+++ b/public/analytics.html
@@ -3,7 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Analytics</title>
+  <meta name="description" content="Explore top schools and subjects by average Leaving Cert points." />
+  <meta name="keywords" content="Leaving Cert analytics, points statistics, school performance" />
+  <meta name="robots" content="index, follow" />
+  <title>Leaving Cert Points Analytics</title>
+  <meta property="og:title" content="Leaving Cert Points Analytics" />
+  <meta property="og:description" content="See top schools and subjects by average Leaving Cert points." />
+  <meta property="og:type" content="website" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous"/>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7429797559685152"
      crossorigin="anonymous"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -4,13 +4,31 @@
   
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Points Probability Calculator — Wizard</title>
+  <meta name="description" content="Interactive Leaving Cert points calculator that estimates your probability of reaching target points." />
+  <meta name="keywords" content="Leaving Cert points calculator, points probabilities, points prediction, Irish Leaving Certificate, LC points" />
+  <meta name="robots" content="index, follow" />
+  <title>Leaving Cert Points Calculator | Points Probability Wizard</title>
+  <meta property="og:title" content="Leaving Cert Points Calculator" />
+  <meta property="og:description" content="Estimate Leaving Cert points and view your chance of achieving target scores." />
+  <meta property="og:type" content="website" />
 
   <!-- Bootstrap 5 -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous"/>
 
   <!-- Chart.js -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    "name": "Leaving Cert Points Calculator",
+    "url": "https://lcpoints.app/",
+    "applicationCategory": "EducationalApplication",
+    "operatingSystem": "Any",
+    "description": "Interactive calculator that predicts Leaving Cert points probabilities."
+  }
+  </script>
 
   <style>
     :root{

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -3,7 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Privacy</title>
+  <meta name="description" content="Privacy policy for LC Points, the Leaving Cert points calculator." />
+  <meta name="keywords" content="privacy policy, LC Points, Leaving Cert points calculator" />
+  <meta name="robots" content="index, follow" />
+  <title>Privacy Policy | LC Points</title>
+  <meta property="og:title" content="Privacy Policy | LC Points" />
+  <meta property="og:description" content="Privacy policy for LC Points, the Leaving Cert points calculator." />
+  <meta property="og:type" content="website" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous"/>
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7429797559685152"
      crossorigin="anonymous"></script>

--- a/public/results.html
+++ b/public/results.html
@@ -3,7 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Results</title>
+  <meta name="description" content="Browse Leaving Cert points results and compare schools against target points." />
+  <meta name="keywords" content="Leaving Cert results, points comparison, school performance" />
+  <meta name="robots" content="index, follow" />
+  <title>Leaving Cert Points Results</title>
+  <meta property="og:title" content="Leaving Cert Points Results" />
+  <meta property="og:description" content="Browse Leaving Cert points results and compare schools against target points." />
+  <meta property="og:type" content="website" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous"/>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7429797559685152"
      crossorigin="anonymous"></script>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+Sitemap: /sitemap.xml
+

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://lcpoints.app/index.html</loc></url>
+  <url><loc>https://lcpoints.app/about.html</loc></url>
+  <url><loc>https://lcpoints.app/privacy.html</loc></url>
+  <url><loc>https://lcpoints.app/results.html</loc></url>
+  <url><loc>https://lcpoints.app/analytics.html</loc></url>
+</urlset>
+


### PR DESCRIPTION
## Summary
- add meta description, keyword, and Open Graph tags across public pages for better search visibility
- include JSON-LD WebApplication schema on the homepage
- add robots.txt and sitemap.xml to guide search engine indexing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a48d8ba1308322b1fa81a335713200