### PR TITLE
Improve scoring clarity and document calculation maths

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -30,6 +30,9 @@
     <p>LC Points is an open-source points probability calculator for the Leaving Certificate.</p>
     <p>The source code is available on <a href="https://github.com/iamharryashton/predictor" target="_blank" rel="noopener">GitHub</a>.</p>
     <p>For enquiries, email <a href="mailto:iamharryashton@gmail.com">iamharryashton@gmail.com</a>.</p>
+    <h2 class="h5 mt-4">How the results are calculated</h2>
+    <p>For each subject you enter the chance of receiving each grade. These probabilities are converted to points using the official Leaving Cert scale. The app combines the subjects using a dynamic programming approach that considers every possible grade combination for your best six subjects. From the resulting distribution we calculate the weighted mean, standard deviation and the probability of meeting your target.</p>
+    <p>This method accounts for every outcome rather than sampling at random, so the results are deterministic and easy to verify.</p>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
 </body>

--- a/public/scoring.html
+++ b/public/scoring.html
@@ -27,35 +27,31 @@
   <div class="container py-4">
     <h1 class="h4 mb-3">Scoring</h1>
     <div class="row">
-      <div class="col-md-6 mb-4">
+      <div class="col-md-6 mb-4 p-3 bg-light rounded">
         <h2 class="h5">Top Schools by Mean Points</h2>
         <ol id="schoolList" class="overflow-auto" style="max-height:10rem"><li class="text-muted">Loading...</li></ol>
       </div>
-      <div class="col-md-6 mb-4">
+      <div class="col-md-6 mb-4 p-3 bg-light rounded">
         <h2 class="h5">Top Subjects by Average Points</h2>
         <ol id="subjectList" class="overflow-auto" style="max-height:10rem"><li class="text-muted">Loading...</li></ol>
       </div>
     </div>
-    <div class="mb-4">
-      <h2 class="h5">
-        <button class="btn btn-link p-0" data-bs-toggle="collapse" data-bs-target="#resultsCollapse" aria-expanded="true">Results</button>
-      </h2>
-      <div class="collapse show" id="resultsCollapse">
-        <div class="table-responsive" style="max-height:50vh; overflow:auto;">
-          <table class="table table-striped">
-            <thead>
-              <tr>
-                <th data-sort="school">School</th>
-                <th data-sort="mean">Mean Points</th>
-                <th data-sort="target">Target Points</th>
-                <th data-sort="createdAt">Date Added</th>
-              </tr>
-            </thead>
-            <tbody id="resultsBody">
-              <tr><td colspan="4" class="text-muted">Loading...</td></tr>
-            </tbody>
-          </table>
-        </div>
+    <div class="mb-4 p-3 bg-light rounded">
+      <h2 class="h5 mb-3">Results, <span id="resultsCount">0 entries</span></h2>
+      <div class="table-responsive" style="max-height:50vh; overflow:auto;">
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th data-sort="school">School</th>
+              <th data-sort="mean">Mean Points</th>
+              <th data-sort="target">Target Points</th>
+              <th data-sort="createdAt">Date Added</th>
+            </tr>
+          </thead>
+          <tbody id="resultsBody">
+            <tr><td colspan="4" class="text-muted">Loading...</td></tr>
+          </tbody>
+        </table>
       </div>
     </div>
   </div>

--- a/public/scoring.js
+++ b/public/scoring.js
@@ -3,6 +3,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const subjectList = document.getElementById('subjectList');
   const listBody = document.getElementById('resultsBody');
   const headers = document.querySelectorAll('th[data-sort]');
+  const resultsCount = document.getElementById('resultsCount');
 
   let entries = [];
   let sortKey = 'createdAt';
@@ -162,16 +163,16 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const schools = Array.from(schoolStats.values())
       .filter(({ count }) => count > 1)
-      .map(({ name, total, count }) => ({ school: name, avg: total / count }))
+      .map(({ name, total, count }) => ({ school: name, avg: total / count, count }))
       .sort((a, b) => b.avg - a.avg);
 
     schoolList.innerHTML = '';
     if (schools.length === 0) {
       schoolList.innerHTML = '<li class="text-muted">No data</li>';
     } else {
-      schools.forEach(({ school, avg }) => {
+      schools.forEach(({ school, avg, count }) => {
         const li = document.createElement('li');
-        li.textContent = `${school} – ${avg.toFixed(1)}`;
+        li.textContent = `${school} (${count} entries) ${avg.toFixed(1)} avg points`;
         schoolList.appendChild(li);
       });
     }
@@ -185,12 +186,14 @@ document.addEventListener('DOMContentLoaded', async () => {
         : null
     }));
 
+    resultsCount.textContent = `${entries.length} entries`;
     render();
   } catch (err) {
     const msg = err.message || String(err);
     subjectList.innerHTML = `<li class="text-danger">${msg}</li>`;
     schoolList.innerHTML = `<li class="text-danger">${msg}</li>`;
     listBody.innerHTML = `<tr><td colspan="4" class="text-danger">${msg}</td></tr>`;
+    if (resultsCount) resultsCount.textContent = '0 entries';
   }
 });
 


### PR DESCRIPTION
## Summary
- Style scoring sections with grey backgrounds and show entry counts in headers and school rankings
- Display total published results beside the results header, removing the old collapse toggle
- Explain in detail how probability and points calculations are performed on the About page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5d855751483229959f0c42a5072b9